### PR TITLE
Update `bugsnag` package for CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "description": "bugsnag logger for book",
   "main": "index.js",
   "dependencies": {
-    "bugsnag": "1.6.3",
+    "bugsnag": "1.7.0",
     "nock": "0.36.2",
     "xtend": "3.0.0"
   },
   "devDependencies": {
-    "mocha": "1.20.1",
-    "book": "1.3.1"
+    "book": "1.3.1",
+    "mocha": "1.20.1"
   },
   "scripts": {
     "test": "mocha --bail --ui qunit --reporter list test/index.js"


### PR DESCRIPTION
Currently we have the following dependency tree:
`book-bugsnag@0.2.0 > bugsnag@1.6.3 > request@2.53.0 > hawk@2.3.1`

This leads to a [vulnerability in hawk](https://nodesecurity.io/advisories/77).

The latest `bugsnag` package has updated its `request` dependency so that this CVE is no longer present.